### PR TITLE
Code fixes and results from interop testing during IETF 122

### DIFF
--- a/os/net/security/edhoc/edhoc-msgs.c
+++ b/os/net/security/edhoc/edhoc-msgs.c
@@ -408,14 +408,10 @@ edhoc_get_key_id_cred_x(uint8_t **p, uint8_t *out_id_cred_x, cose_key_t *key)
     key->kid_sz = 1;
     ptr = key->kid;
 
-    if(key->kid[0] == 0) {
-      /* Read variable-length KID */
-      key->kid_sz = edhoc_get_bytes(p, &ptr);
-      memcpy(key->kid, ptr, key->kid_sz);
-    }
     label = 0;
   }
 
+  /* Note that currently only ID_CRED_R as KID is supported */
   switch(label) {
   case 0:
     /* ID_CRED_R = KID (compact encoding) */


### PR DESCRIPTION
During the IETF 122 Hackathon I performed interop testing of the EDHOC client from this codebase towards 2 other implementations.

## Testing against the EDHOC server from our Java implementation of EDHOC

This was tested successfully in the past.

### Repo with code for implementation

https://github.com/rikard-sics/contiki-ng/tree/edhoc

### Configuration

Credential type: CCS
ID cred type: KID
Cipher suite: 2
Method: 0 & 3

### Results

Success. The Contiki-NG code is still compatible and works with the Java code.

### Testing against the EDHOC server made by Christian Amsüss located at demo.coap.amsuess.com

This was never tested successfully before.

### Repo with code for implementation

https://github.com/chrysn/aiocoap

### Configuration

Credential type: CCS
ID cred type: KID
Cipher suite: 2
Method: 3

### Results

Success. But see the notes below.

Initially this did not work because the server only supported credentials included "by value", i.e. with their actual value and not just an identifier as a reference. However, this is a known limitation in the Contiki-NG code and the implementation only supports credentials "by reference".

Fortunately Christian Amsüss was able to update his server to also support "credentials by reference", identified by KID. To successfully make this test work I needed to remove 5 lines of code from the current implementation. These lines were meant to support multi-byte KIDs but did not work correctly. Thus, the implementation only supports KIDs of length 1 byte.